### PR TITLE
Add tolerance to `krylov_schur`

### DIFF
--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1085,7 +1085,7 @@ class GPCCA(object):
 
     """
 
-    def __init__(self, P, eta=None, z='LM', method='brandts'):
+    def __init__(self, P, eta=None, z='LM', method='brandts', tol_krylov=1e-8):
         from msmtools.analysis import is_transition_matrix
 
         if not is_transition_matrix(P):

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -202,9 +202,6 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
         'krylov': Calculate an orthonormal basis of the subspace 
          associated with the `m` dominant eigenvalues of `P` 
          using the Krylov-Schur method as implemented in SLEPc.
-        'scipy': Perform a full Schur decomposition of `P` while
-         sorting up `m` (`m` < `n`) dominant eigenvalues 
-         (and associated Schur vectors) at the same time.
 
     tol_krylov : float, (default=1e-16)
         Convergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
@@ -837,13 +834,6 @@ def gpcca_coarsegrain(P, eta, m, z='LM', method='brandts'):
          matrix Q afterwards using a routine published by Brandts.
          This is well tested und thus the default method, 
          although it is also the slowest choice.
-         'scipy': Perform a full Schur decomposition of `P` 
-         while sorting up `m` (`m` < `n`) dominant eigenvalues 
-         (and associated Schur vectors) at the same time.
-         This will be faster than `brandts`, if `P` is large 
-         (n > 1000) and you sort a large part of the spectrum,
-         because your number of clusters `m` is large (>20).
-         This is still experimental, so use with CAUTION!
         'krylov': Calculate an orthonormal basis of the subspace 
          associated with the `m` dominant eigenvalues of `P` 
          using the Krylov-Schur method as implemented in SLEPc.

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -924,13 +924,6 @@ class GPCCA(object):
          matrix Q afterwards using a routine published by Brandts.
          This is well tested und thus the default method, 
          although it is also the slowest choice.
-         'scipy': Perform a full Schur decomposition of `P` 
-         while sorting up `m` (`m` < `n`) dominant eigenvalues 
-         (and associated Schur vectors) at the same time.
-         This will be faster than `brandts`, if `P` is large 
-         (n > 1000) and you sort a large part of the spectrum,
-         because your number of clusters `m` is large (>20).
-         This is still experimental, so use with CAUTION!
         'krylov': Calculate an orthonormal basis of the subspace 
          associated with the `m` dominant eigenvalues of `P` 
          using the Krylov-Schur method as implemented in SLEPc.
@@ -1087,11 +1080,11 @@ class GPCCA(object):
             raise ValueError("Input matrix P is not a transition matrix.")
         if z not in ['LM', 'LR']:
             raise ValueError("You didn't give a valid sorting criterion z. Valid options are `'LM'` and `'LR'`.")
-        if method not in ['brandts', 'scipy', 'krylov']:
+        if method not in ['brandts', 'krylov']:
             raise ValueError("You didn't give a valid method to determine the invariant subspace.")
           
         if issparse(P) and method != 'krylov':
-            warnings.warn("Sorted Schur decoposition via the methods `brandts` and `scipy` is only implemented "
+            warnings.warn("Sorted Schur decoposition via the method `brandts` is only implemented "
                           "for dense matrices. Converting sparse transition matrix to dense ndarray.")
             P = P.toarray()
 

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -207,7 +207,7 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
          (and associated Schur vectors) at the same time.
 
     tol_krylov : float, (default=1e-16)
-        Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
+        Convergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
         dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
         
     Returns

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -206,7 +206,7 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
          sorting up `m` (`m` < `n`) dominant eigenvalues 
          (and associated Schur vectors) at the same time.
 
-    tol_krylov : float, (default=1e-8)
+    tol_krylov : float, (default=1e-16)
         Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
         dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
         

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -161,7 +161,7 @@ def _gram_schmidt_mod(X, eta):
     return Q
 
 
-def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-8):
+def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
     r"""
     This function performs a Schur decomposition of the (n,n) transition matrix `P`, with due regard 
     to the input (initial) distribution of states `eta` (which can be the stationary distribution ``pi``,
@@ -957,10 +957,6 @@ class GPCCA(object):
          ``Successfully installed [package name here]``.
          ------------------------------------------------------
 
-    tol_krylov : float, (default=1e-8)
-        Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
-        dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
-        
     Properties
     ----------
     
@@ -1084,7 +1080,7 @@ class GPCCA(object):
 
     """
 
-    def __init__(self, P, eta=None, z='LM', method='brandts', tol_krylov=1e-8):
+    def __init__(self, P, eta=None, z='LM', method='brandts'):
         from msmtools.analysis import is_transition_matrix
 
         if not is_transition_matrix(P):
@@ -1112,7 +1108,6 @@ class GPCCA(object):
         self.R = None
         self.z = z
         self.method = method
-        self.tol_krylov = tol_krylov
 
     def _do_schur_helper(self, m):
         n = np.shape(self.P)[0]
@@ -1123,9 +1118,9 @@ class GPCCA(object):
                     raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                      f"with the dimension of P [{n}, {n}].")
                 if Xdim2 < m:
-                    self.X = _do_schur(self.P, self.eta, m, self.z, self.method, self.tol_krylov)
+                    self.X = _do_schur(self.P, self.eta, m, self.z, self.method)
             else:
-                self.X = _do_schur(self.P, self.eta, m, self.z, self.method, self.tol_krylov)
+                self.X = _do_schur(self.P, self.eta, m, self.z, self.method)
         else:
             if self.X is not None and self.R is not None:
                 Xdim1, Xdim2 = self.X.shape
@@ -1139,9 +1134,9 @@ class GPCCA(object):
                     raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                      f"with the dimension of R [{Rdim1}, {Rdim2}].")
                 if Rdim2 < m:
-                    self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method, self.tol_krylov)
+                    self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method)
             else:
-                self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method, self.tol_krylov)
+                self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method)
 
     def minChi(self, m_min, m_max):
         r"""

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -574,9 +574,8 @@ def _opt_soft(X, rot_matrix):
         else:
             chi[chi < 0.0] = 0.0
             chi = np.diag(np.true_divide(1.0, np.sum(chi, axis=1))).dot(chi)
-            if not np.allclose(np.sum(chi, axis=1), 1.0, rtol=eps, atol=eps):
-                raise ValueError("The rows of chi don't sum up to 1.0 after rescaling "
-                                 + "(with a absolute and relative tolerance of " + str(eps) + ").")
+            if not np.allclose(np.sum(chi, axis=1), 1.0, atol=1e-8, rtol=1e-5):
+                raise ValueError("The rows of chi don't sum up to 1.0 after rescaling")
             
     return rot_matrix, chi, fopt
   

--- a/msmtools/analysis/sparse/stationary_vector.py
+++ b/msmtools/analysis/sparse/stationary_vector.py
@@ -141,22 +141,5 @@ def stationary_distribution(T):
 
     """
     mu = stationary_distribution_from_eigenvector(T)
-    # if np.any(mu < 0):  # still? Then set to 0 and renormalize
-    #     mu = np.maximum(mu, 0.0)
-    #     mu /= mu.sum()
-
-    # fallback = False
-    # try:
-    #     mu = stationary_distribution_from_backward_iteration(T)
-    #     if np.any(mu < 0):  # numerical problem, fall back to more robust algorithm.
-    #         fallback=True
-    # except RuntimeError:
-    #     fallback = True
-    #
-    # if fallback:
-    #     mu = stationary_distribution_from_eigenvector(T)
-    #     if np.any(mu < 0):  # still? Then set to 0 and renormalize
-    #         mu = np.maximum(mu, 0.0)
-    #         mu /= mu.sum()
 
     return mu

--- a/msmtools/analysis/sparse/stationary_vector.py
+++ b/msmtools/analysis/sparse/stationary_vector.py
@@ -135,7 +135,7 @@ def stationary_distribution_from_eigenvector(T, ncv=None):
     top_vec = top_vec.real
 
     # check the sign structure
-    if not (top_vec > -EPS).all() and not (top_vec < EPS).all():
+    if not (top_vec > -1e4*EPS).all() and not (top_vec < 1e4*EPS).all():
         raise ValueError('Top eigenvector has both positive and negative entries')
     top_vec = np.abs(top_vec)
 

--- a/msmtools/analysis/sparse/stationary_vector.py
+++ b/msmtools/analysis/sparse/stationary_vector.py
@@ -121,10 +121,10 @@ def stationary_distribution_from_eigenvector(T, ncv=None):
     """
 
     # get the top two eigenvalues and vecs so we can check for irreducibility
-    vals, vecs = scipy.sparse.linalg.eigs(T.transpose(), k=2, which='LM', ncv=ncv)
+    vals, vecs = scipy.sparse.linalg.eigs(T.transpose(), k=2, which='LR', ncv=ncv)
 
     # check for irreducibility
-    if np.allclose(np.abs(vals), 1, rtol=EPS, atol=EPS):
+    if np.allclose(vals, 1, rtol=EPS, atol=EPS):
         raise ValueError('This matrix is reducible')
 
     # check for imaginary component

--- a/msmtools/analysis/sparse/stationary_vector.py
+++ b/msmtools/analysis/sparse/stationary_vector.py
@@ -119,7 +119,7 @@ def stationary_distribution_from_eigenvector(T, ncv=None):
 
     """
     vals, vecs = scipy.sparse.linalg.eigs(T.transpose(), k=1, which='LR', ncv=ncv)
-    nu = vecs[:, 0].real
+    nu = np.abs(vecs[:, 0].real)
     mu = nu / np.sum(nu)
     return mu
 
@@ -140,18 +140,23 @@ def stationary_distribution(T):
         Vector of stationary probabilities.
 
     """
-    fallback = False
-    try:
-        mu = stationary_distribution_from_backward_iteration(T)
-        if np.any(mu < 0):  # numerical problem, fall back to more robust algorithm.
-            fallback=True
-    except RuntimeError:
-        fallback = True
+    mu = stationary_distribution_from_eigenvector(T)
+    # if np.any(mu < 0):  # still? Then set to 0 and renormalize
+    #     mu = np.maximum(mu, 0.0)
+    #     mu /= mu.sum()
 
-    if fallback:
-        mu = stationary_distribution_from_eigenvector(T)
-        if np.any(mu < 0):  # still? Then set to 0 and renormalize
-            mu = np.maximum(mu, 0.0)
-            mu /= mu.sum()
+    # fallback = False
+    # try:
+    #     mu = stationary_distribution_from_backward_iteration(T)
+    #     if np.any(mu < 0):  # numerical problem, fall back to more robust algorithm.
+    #         fallback=True
+    # except RuntimeError:
+    #     fallback = True
+    #
+    # if fallback:
+    #     mu = stationary_distribution_from_eigenvector(T)
+    #     if np.any(mu < 0):  # still? Then set to 0 and renormalize
+    #         mu = np.maximum(mu, 0.0)
+    #         mu /= mu.sum()
 
     return mu

--- a/msmtools/analysis/sparse/stationary_vector.py
+++ b/msmtools/analysis/sparse/stationary_vector.py
@@ -124,11 +124,15 @@ def stationary_distribution_from_eigenvector(T, ncv=None):
     vals, vecs = scipy.sparse.linalg.eigs(T.transpose(), k=2, which='LR', ncv=ncv)
 
     # check for irreducibility
-    if np.allclose(vals, 1, rtol=EPS, atol=EPS):
+    if np.allclose(vals, 1, rtol=1e2*EPS, atol=1e2*EPS):
         raise ValueError('This matrix is reducible')
 
-    # check for imaginary component
+    # sort by real part and take the top one
+    p = np.argsort(vals.real)[::-1]
+    vecs = vecs[:, p]
     top_vec = vecs[:, 0]
+
+    # check for imaginary component
     imaginary_component = top_vec.imag
     if not np.allclose(imaginary_component, 0, rtol=EPS, atol=EPS):
         raise ValueError('Top eigenvector has imaginary component')

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -43,9 +43,9 @@ def top_eigenvalues(P, m, z='LM', tol=1e-8):
         'LM': the m eigenvalues with the largest magnitude are sorted up.
         'LR': the m eigenvalues with the largest real part are sorted up.
 
-    tol : float, (default='1e-8')
+    tol : float, (default=1e-8)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
-        conditioned matrices, consider decreasing this value to get acccurate results.
+        conditioned matrices, consider decreasing this value to get accurate results.
         
     """    
     n = P.shape[0]
@@ -140,9 +140,9 @@ def smallest_eigenvalue(P, z='SM', tol=1e-8):
         'SM': eigenvalue with the smallest magnitude.
         'SR': eigenvalue with the smallest real part.
 
-    tol : float, (default='1e-8')
+    tol : float, (default=1e-8)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
-        conditioned matrices, consider decreasing this value to get acccurate results.
+        conditioned matrices, consider decreasing this value to get accurate results.
         
     """    
     from petsc4py import PETSc
@@ -311,9 +311,9 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-8):
         'LM': Largest magnitude (default).
         'LR': Largest real parts.
 
-    tol : float, (default='1e-8')
+    tol : float, (default=1e-8)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
-        conditioned matrices, consider decreasing this value to get acccurate results.
+        conditioned matrices, consider decreasing this value to get accurate results.
         
     """
     from petsc4py import PETSc
@@ -478,9 +478,9 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-8):
          sorting up `m` (`m` < `n`) dominant eigenvalues 
          (and associated Schur vectors) at the same time.
 
-    tol : float, (default='1e-8')
+    tol_krylov : float, (default=1e-8)
         Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
-        dealing with ill conditioned matrices, consider decreasing this value to get acccurate results.
+        dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
         
     """
     if method == 'krylov':

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -126,61 +126,6 @@ def top_eigenvalues(P, m, z='LM', tol=1e-16):
     return top_eigenvals, block_split
 
 
-def smallest_eigenvalue(P, z='SM', tol=1e-16):
-    r"""
-    Find the smallest eigenvalue according to an selectable criterion.
-    
-    Parameters
-    ----------
-    P : ndarray (n,n)
-        
-    z : string, (default='LM')
-        Criterion according to which the smallest eigenvalue is selected.
-        Options are:
-        'SM': eigenvalue with the smallest magnitude.
-        'SR': eigenvalue with the smallest real part.
-
-    tol : float, (default=1e-16)
-        Confergence criterion used by SLEPc internally. If you are dealing with ill
-        conditioned matrices, consider decreasing this value to get accurate results.
-        
-    """    
-    from petsc4py import PETSc
-    from slepc4py import SLEPc 
-    
-    M = PETSc.Mat().create()
-    _initialize_matrix(M, P)
-    # Creates EPS object.
-    E = SLEPc.EPS()
-    E.create()
-    # Set the matrix associated with the eigenvalue problem.
-    E.setOperators(M)
-    # Select the particular solver to be used in the EPS object: Krylov-Schur
-    E.setType(SLEPc.EPS.Type.KRYLOVSCHUR)
-    # Set the number of eigenvalues to compute and the dimension of the subspace.
-    E.setDimensions(nev=1)
-    # set the tolerance used in the convergence criterion
-    E.setTolerances(tol=tol)
-
-    if z == 'SM':
-        E.setWhichEigenpairs(E.Which.SMALLEST_MAGNITUDE)
-    elif z == 'SR':
-        E.setWhichEigenpairs(E.Which.SMALLEST_REAL)
-    else:
-        raise ValueError(f"Invalid spectrum sorting options `{z}`. Valid options are: `'SM'`, `'SR'`")
-    # Solve the eigensystem.
-    E.solve()
-
-    nconv = E.getConverged()
-    # Warn, if nconv smaller than 1.
-    if nconv < 1:
-        warnings.warn("The number of converged eigenpairs is too small.")
-    # Get the smallest eigenvalue.
-    smallest_eigenval = E.getEigenvalue(0)
-    
-    return smallest_eigenval
-
-
 def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
     r"""
     Calculate an orthonormal basis of the subspace associated with the `m`

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -479,7 +479,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
          (and associated Schur vectors) at the same time.
 
     tol_krylov : float, (default=1e-16)
-        Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
+        Convergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
         dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
         
     """

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -22,7 +22,7 @@ def _initialize_matrix(M, P):
         M.createDense(list(np.shape(P)), array=P)
 
 
-def top_eigenvalues(P, m, z='LM', tol=1e-8):
+def top_eigenvalues(P, m, z='LM', tol=1e-16):
     r"""
     Sort `m+1` (if ``m < n``) or `m` (if ``m == n``) dominant eigenvalues 
     up and check (if ``m < n``), if clustering into `m` clusters would split 
@@ -43,7 +43,7 @@ def top_eigenvalues(P, m, z='LM', tol=1e-8):
         'LM': the m eigenvalues with the largest magnitude are sorted up.
         'LR': the m eigenvalues with the largest real part are sorted up.
 
-    tol : float, (default=1e-8)
+    tol : float, (default=1e-16)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
         conditioned matrices, consider decreasing this value to get accurate results.
         
@@ -126,7 +126,7 @@ def top_eigenvalues(P, m, z='LM', tol=1e-8):
     return top_eigenvals, block_split
 
 
-def smallest_eigenvalue(P, z='SM', tol=1e-8):
+def smallest_eigenvalue(P, z='SM', tol=1e-16):
     r"""
     Find the smallest eigenvalue according to an selectable criterion.
     
@@ -140,7 +140,7 @@ def smallest_eigenvalue(P, z='SM', tol=1e-8):
         'SM': eigenvalue with the smallest magnitude.
         'SR': eigenvalue with the smallest real part.
 
-    tol : float, (default=1e-8)
+    tol : float, (default=1e-16)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
         conditioned matrices, consider decreasing this value to get accurate results.
         
@@ -271,7 +271,7 @@ def sorted_scipy_schur(P, m, z='LM'):
     return (R, Q)
 
 
-def sorted_krylov_schur(P, m, z='LM', tol=1e-8):
+def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
     r"""
     Calculate an orthonormal basis of the subspace associated with the `m`
     dominant eigenvalues of `P` using the Krylov-Schur method as implemented
@@ -311,7 +311,7 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-8):
         'LM': Largest magnitude (default).
         'LR': Largest real parts.
 
-    tol : float, (default=1e-8)
+    tol : float, (default=1e-16)
         Confergence criterion used by SLEPc internally. If you are dealing with ill
         conditioned matrices, consider decreasing this value to get accurate results.
         
@@ -442,7 +442,7 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-8):
     return Q, top_eigenvals, top_eigenvals_error
 
 
-def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-8):
+def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
     r"""
     Return `m` dominant real Schur vectors or an orthonormal basis
     spanning the same invariant subspace, utilizing selectable methods
@@ -478,7 +478,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-8):
          sorting up `m` (`m` < `n`) dominant eigenvalues 
          (and associated Schur vectors) at the same time.
 
-    tol_krylov : float, (default=1e-8)
+    tol_krylov : float, (default=1e-16)
         Confergence criterion used by SLEPc internally. This is only relevant if you use method=`krylov`. If you are
         dealing with ill conditioned matrices, consider decreasing this value to get accurate results.
         

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -322,7 +322,7 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-8):
     # Calculate the top m+1 eigenvalues and secure that you
     # don't separate conjugate eigenvalues (corresponding to 2x2-block in R),
     # if you take the dominant m eigenvalues to cluster the data.
-    top_eigenvals, block_split = top_eigenvalues(P, m, z=z)
+    top_eigenvals, block_split = top_eigenvalues(P, m, z=z, tol=tol)
     
     if block_split:
         raise ValueError(f"Clustering P into `{m}` clusters will split "

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -44,7 +44,7 @@ def top_eigenvalues(P, m, z='LM', tol=1e-16):
         'LR': the m eigenvalues with the largest real part are sorted up.
 
     tol : float, (default=1e-16)
-        Confergence criterion used by SLEPc internally. If you are dealing with ill
+        Convergence criterion used by SLEPc internally. If you are dealing with ill
         conditioned matrices, consider decreasing this value to get accurate results.
         
     """    


### PR DESCRIPTION
This adds the possibility to change the convergence threshold used internally by SLEPc. Default is 1e-8, which is SLEPc's default. It also relaxes the tolerance used for checking whether the rows of the memberships vectors sum to one.

This solves my problems with `krylov_schur` not returning invariant subspaces for ill-conditioned matrices. 