### PR TITLE
Remove SLEPSc dependency for `brandts`

### DIFF
--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1114,12 +1114,12 @@ class GPCCA(object):
                                  f"with the dimension of R [{Rdim1}, {Rdim2}].")
             if Rdim2 < m:
                 self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
-
-            # if we are using pre-computed decomposition, check splitting
-            if m < n:
-                if _check_conj_splitting(self.eigenvalues, m):
-                    raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
-                                     f'Request one cluster more or less. ')
+            else:
+                # if we are using pre-computed decomposition, check splitting
+                if m < n:
+                    if _check_conj_splitting(self.eigenvalues, m):
+                        raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
+                                         f'Request one cluster more or less. ')
         else:
             self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
 

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1120,6 +1120,7 @@ class GPCCA(object):
                         if _check_conj_splitting(self.eigenvalues, m):
                             raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                                              f'Request one cluster more or less. ')
+                        print('INFO: Using pre-computed schur decomposition')
         else:
             self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
 

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1110,7 +1110,7 @@ class GPCCA(object):
                 raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                  f"with the dimension of R [{Rdim1}, {Rdim2}].")
             if n_evals != Rdim1:
-                raise ValueError(f"The number of eigenvalues is {n_evals}. This doesn't match"
+                raise ValueError(f"The number of eigenvalues is `{n_evals}`. This doesn't match "
                                  f"with the dimension of R [{Rdim1}, {Rdim2}].")
             if Rdim2 < m:
                 self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -247,16 +247,15 @@ def _do_schur(P, eta, m, z='LM', method='brandts'):
 
     # Make a Schur decomposition of P_bar and sort the Schur vectors (and form).
     R, Q = sorted_schur(P_bar, m, z, method) #Pbar!!!
-    if method != "krylov":
-        if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
-            warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
-                          + "a block of complex conjugate eigenvalues in the Schur "
-                          + "form. The result will be of questionable meaning. "
-                          + "Please increase/decrease number of states by one.")
-        # Since the Schur form R and Schur vectors are only partially
-        # sorted, one doesn't need the whole R and Schur vector matrix Q.
-        # Take only the sorted Schur form and the vectors belonging to it.
-        R = R[:m, :m]
+    if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
+        warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
+                      + "a block of complex conjugate eigenvalues in the Schur "
+                      + "form. The result will be of questionable meaning. "
+                      + "Please increase/decrease number of states by one.")
+    # Since the Schur form R and Schur vectors are only partially
+    # sorted, one doesn't need the whole R and Schur vector matrix Q.
+    # Take only the sorted Schur form and the vectors belonging to it.
+    R = R[:m, :m]
 
     Q = Q[:, :m]
     

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -246,10 +246,8 @@ def _do_schur(P, eta, m, z='LM', method='brandts'):
         P_bar = np.diag(np.sqrt(eta)).dot(P).dot(np.diag(1. / np.sqrt(eta)))
 
     # Make a Schur decomposition of P_bar and sort the Schur vectors (and form).
-    if method == 'krylov':
-        Q = sorted_schur(P_bar, m, z, method) #Pbar!!!
-    else:
-        R, Q = sorted_schur(P_bar, m, z, method) #Pbar!!!
+    R, Q = sorted_schur(P_bar, m, z, method) #Pbar!!!
+    if method != "krylov":
         if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
             warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
                           + "a block of complex conjugate eigenvalues in the Schur "
@@ -259,7 +257,7 @@ def _do_schur(P, eta, m, z='LM', method='brandts'):
         # sorted, one doesn't need the whole R and Schur vector matrix Q.
         # Take only the sorted Schur form and the vectors belonging to it.
         R = R[:m, :m]
-        
+
     Q = Q[:, :m]
     
     # Orthonormalize the sorted Schur vectors Q via modified Gram-Schmidt-orthonormalization,
@@ -298,18 +296,15 @@ def _do_schur(P, eta, m, z='LM', method='brandts'):
         raise ValueError("Schur vectors appear to not be D-orthogonal.")
     # Raise, if X doesn't fullfill the invariant subspace condition!
 
-    if method == 'krylov':
-        dp = np.dot(P, sp.csr_matrix(X) if issparse(P) else X)
-        dummy = subspace_angles(dp.toarray() if issparse(dp) else dp, X)
-    else:
-        dummy = subspace_angles(np.dot(P, X), np.dot(X, R))
+    dp = np.dot(P, sp.csr_matrix(X) if issparse(P) else X)
+    dummy = subspace_angles(dp.toarray() if issparse(dp) else dp, np.dot(X, R))
 
     test = np.allclose(dummy, 0.0, atol=1e-6, rtol=1e-5)
     test1 = (dummy.shape[0] == m)
     if not test:
         raise ValueError(f"According to scipy.linalg.subspace_angles() X isn't an invariant "
                          f"subspace of P, since the subspace angles between the column spaces "
-                         f"of P*X and X*R (resp. X, if you chose the Krylov-Schur method)"
+                         f"of P*X and X*R (resp. X, if you chose the Krylov-Schur method) "
                          f"aren't near zero. The subspace angles are: `{dummy}`")
     elif not test1:
         warnings.warn("According to scipy.linalg.subspace_angles() the dimension of the "
@@ -319,9 +314,6 @@ def _do_schur(P, eta, m, z='LM', method='brandts'):
     if not np.allclose(X[:, 0], 1.0, atol=1e-8, rtol=1e-5):
         raise ValueError("The first column X[:, 0] of the Schur vector matrix isn't constantly equal 1.")
                   
-    if method == 'krylov':
-        return X
-
     return X, R
 
 
@@ -1108,32 +1100,21 @@ class GPCCA(object):
 
     def _do_schur_helper(self, m):
         n = np.shape(self.P)[0]
-        if self.method == 'krylov':
-            if self.X is not None:
-                Xdim1, Xdim2 = self.X.shape
-                if Xdim1 != n:
-                    raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
-                                     f"with the dimension of P [{n}, {n}].")
-                if Xdim2 < m:
-                    self.X = _do_schur(self.P, self.eta, m, self.z, self.method)
-            else:
-                self.X = _do_schur(self.P, self.eta, m, self.z, self.method)
-        else:
-            if self.X is not None and self.R is not None:
-                Xdim1, Xdim2 = self.X.shape
-                Rdim1, Rdim2 = self.R.shape
-                if Xdim1 != n:
-                    raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
-                                     f"with the dimension of P [{n}, {n}].")
-                if Rdim1 != Rdim2:
-                    raise ValueError("The Schur form R is not quadratic.")
-                if Xdim2 != Rdim1:
-                    raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
-                                     f"with the dimension of R [{Rdim1}, {Rdim2}].")
-                if Rdim2 < m:
-                    self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method)
-            else:
+        if self.X is not None and self.R is not None:
+            Xdim1, Xdim2 = self.X.shape
+            Rdim1, Rdim2 = self.R.shape
+            if Xdim1 != n:
+                raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
+                                 f"with the dimension of P [{n}, {n}].")
+            if Rdim1 != Rdim2:
+                raise ValueError("The Schur form R is not quadratic.")
+            if Xdim2 != Rdim1:
+                raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
+                                 f"with the dimension of R [{Rdim1}, {Rdim2}].")
+            if Rdim2 < m:
                 self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method)
+        else:
+            self.X, self.R = _do_schur(self.P, self.eta, m, self.z, self.method)
 
     def minChi(self, m_min, m_max):
         r"""
@@ -1372,10 +1353,7 @@ class GPCCA(object):
         self._rot_matrix = rot_matrix_list[opt_idx]
         self._crispness = crispness_list[opt_idx]
         self._X = self.X[:, :self._m_opt]
-        if self.method == 'krylov':
-            self._R = None
-        else:
-            self._R = self.R[:self._m_opt, :self._m_opt]
+        self._R = self.R[:self._m_opt, :self._m_opt]
 
         # stationary distribution
         from msmtools.analysis import stationary_distribution as _stationary_distribution
@@ -1427,8 +1405,6 @@ class GPCCA(object):
     
     @property
     def schur_matrix(self):
-        if self._R is None:
-            warnings.warn("The Schur form R is not defined, because you chose `method='krylov'`.")
         return self._R
     
     @property

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1100,7 +1100,6 @@ class GPCCA(object):
         if self.X is not None and self.R is not None and self.eigenvalues is not None:
             Xdim1, Xdim2 = self.X.shape
             Rdim1, Rdim2 = self.R.shape
-            n_evals = len(self.eigenvalues)
             if Xdim1 != n:
                 raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                  f"with the dimension of P [{n}, {n}].")
@@ -1109,17 +1108,18 @@ class GPCCA(object):
             if Xdim2 != Rdim1:
                 raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                  f"with the dimension of R [{Rdim1}, {Rdim2}].")
-            if n_evals != Rdim1:
-                raise ValueError(f"The number of eigenvalues is `{n_evals}`. This doesn't match "
-                                 f"with the dimension of R [{Rdim1}, {Rdim2}].")
             if Rdim2 < m:
                 self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
             else:
                 # if we are using pre-computed decomposition, check splitting
                 if m < n:
-                    if _check_conj_splitting(self.eigenvalues, m):
-                        raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
-                                         f'Request one cluster more or less. ')
+                    if len(self.eigenvalues) < m+1:
+                        raise ValueError(f"Can't check compl. conj. block splitting for {m} clusters with only "
+                                         "{len(self.eigenvalues} eigenvalues")
+                    else:
+                        if _check_conj_splitting(self.eigenvalues, m):
+                            raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
+                                             f'Request one cluster more or less. ')
         else:
             self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
 

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -247,17 +247,18 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
         P_bar = np.diag(np.sqrt(eta)).dot(P).dot(np.diag(1. / np.sqrt(eta)))
 
     # Make a Schur decomposition of P_bar and sort the Schur vectors (and form).
-    R, Q = sorted_schur(P_bar, m, z, method, tol_krylov=tol_krylov) #Pbar!!!
-    if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
-        warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
-                      + "a block of complex conjugate eigenvalues in the Schur "
-                      + "form. The result will be of questionable meaning. "
-                      + "Please increase/decrease number of states by one.")
-    # Since the Schur form R and Schur vectors are only partially
-    # sorted, one doesn't need the whole R and Schur vector matrix Q.
-    # Take only the sorted Schur form and the vectors belonging to it.
-    R = R[:m, :m]
-    Q = Q[:, :m]
+    R, Q, eigenvalues = sorted_schur(P_bar, m, z, method, tol_krylov=tol_krylov) #Pbar!!!
+
+    # if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
+    #     warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
+    #                   + "a block of complex conjugate eigenvalues in the Schur "
+    #                   + "form. The result will be of questionable meaning. "
+    #                   + "Please increase/decrease number of states by one.")
+    # # Since the Schur form R and Schur vectors are only partially
+    # # sorted, one doesn't need the whole R and Schur vector matrix Q.
+    # # Take only the sorted Schur form and the vectors belonging to it.
+    # R = R[:m, :m]
+    # Q = Q[:, :m]
     
     # Orthonormalize the sorted Schur vectors Q via modified Gram-Schmidt-orthonormalization,
     # if the (Schur)vectors aren't orthogonal!

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1115,7 +1115,7 @@ class GPCCA(object):
                 if m < n:
                     if len(self.eigenvalues) < m+1:
                         raise ValueError(f"Can't check compl. conj. block splitting for {m} clusters with only "
-                                         "{len(self.eigenvalues} eigenvalues")
+                                         f"{len(self.eigenvalues)} eigenvalues")
                     else:
                         if _check_conj_splitting(self.eigenvalues, m):
                             raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -365,9 +365,16 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
    
         # Make a Schur decomposition of P.
         R, Q = schur(P, output='real')
+
+        # sort one more than requested
+        n = P.shape[0]
+        if m < n:
+            k = m + 1
+        elif m == n:
+            k = m
         
         # Sort the Schur matrix and vectors.
-        Q, R, ap = sort_real_schur(Q, R, z=z, b=m)
+        Q, R, ap = sort_real_schur(Q, R, z=z, b=k)
 
         # comptue eigenvalues
         T, _ = rsf2csf(R, Q)

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -267,14 +267,14 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
         top_eigenvals_error.append(eigenval_error)
 
     # cut off excess dimensions also for the eigenvalues
-    top_eigenvals = np.asarray(top_eigenvals)[:m]
-    top_eigenvals_error = np.asarray(top_eigenvals_error)[:m]
+    top_eigenvals = np.asarray(top_eigenvals)
+    top_eigenvals_error = np.asarray(top_eigenvals_error)
 
     dummy = np.dot(P, csr_matrix(Q) if issparse(P) else Q)
     if issparse(dummy):
         dummy = dummy.toarray()
 
-    dummy1 = np.dot(Q, np.diag(top_eigenvals))
+    dummy1 = np.dot(Q, np.diag(top_eigenvals[:m]))
 #     dummy2 = np.concatenate((dummy, dummy1), axis=1)
     dummy3 = subspace_angles(dummy, dummy1)
 #     test1 = ( ( matrix_rank(dummy2) - matrix_rank(dummy) ) == 0 )
@@ -390,7 +390,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
             if np.isclose(eigenval_in, np.conj(eigenval_out)):
                 raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                                  f'Request one cluster more or less. ')
-            Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m]
+            Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues
 
         # Warnings
         if np.any(np.array(ap) > 1.0):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -5,6 +5,7 @@ import warnings
 from scipy.linalg import schur, subspace_angles
 from msmtools.util.sort_real_schur import sort_real_schur
 from scipy.sparse import issparse, isspmatrix_csr, csr_matrix
+from scipy.linalg import rsf2csf
 
 # Machine double floating precision:
 eps = np.finfo(np.float64).eps
@@ -367,6 +368,11 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         
         # Sort the Schur matrix and vectors.
         Q, R, ap = sort_real_schur(Q, R, z=z, b=m)
+
+        # comptue eigenvalues
+        T, _ = rsf2csf(R, Q)
+        eigenvalues = np.diag(T)
+
         # Warnings
         if np.any(np.array(ap) > 1.0):
             warnings.warn("Reordering of Schur matrix was inaccurate.")

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -248,6 +248,7 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
 #                       + "invariant subspace associated with the sorted top m eigenvalues.")
     # Cut off, if too large.
     Q = Subspace[:, :m]
+    R = R[:m, :m]
     
     # Gets the number of converged eigenpairs. 
     nconv = E.getConverged()

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -394,8 +394,8 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         if np.any(np.array(ap) > 1.0):
             warnings.warn("Reordering of Schur matrix was inaccurate.")
     elif method == 'krylov':
-        R, Q, _, _ = sorted_krylov_schur(P, m, z=z, tol=tol_krylov)
+        R, Q, eigenvalues, _ = sorted_krylov_schur(P, m, z=z, tol=tol_krylov)
     else:
         raise ValueError(f"Unknown method `{method!r}`.")
        
-    return R, Q
+    return R, Q, eigenvalues

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -386,7 +386,8 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
             eigenval_in = eigenvalues[m - 1]
             eigenval_out = eigenvalues[m]
             if np.isclose(eigenval_in, np.conj(eigenval_out)):
-                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvales. Request one cluster more or less. ')
+                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvales. '
+                                 f'Request one cluster more or less. ')
 
         # Warnings
         if np.any(np.array(ap) > 1.0):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -362,7 +362,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         # Calculate the top m+1 eigenvalues and secure that you
         # don't separate conjugate eigenvalues (corresponding to 2x2-block in R),
         # if you take the dominant m eigenvalues to cluster the data.
-        _ = top_eigenvalues(P, m, z=z, tol=tol_krylov)
+        #  _ = top_eigenvalues(P, m, z=z, tol=tol_krylov)
    
         # Make a Schur decomposition of P.
         R, Q = schur(P, output='real')

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -378,7 +378,16 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
 
         # comptue eigenvalues
         T, _ = rsf2csf(R, Q)
-        eigenvalues = np.diag(T)
+        eigenvalues = np.diag(T)[:k]
+
+        if (m < n):
+            eigenval_in = eigenvalues[m - 1]
+            eigenval_out = eigenvalues[m]
+            # Don't separate conjugate eigenvalues (corresponding to 2x2-block in R).
+            if np.isclose(eigenval_in, np.conj(eigenval_out)):
+                block_split = True
+                warnings.warn("Clustering into " + str(m) + " clusters will split conjugate eigenvalues! "
+                                                            "Request one cluster more or less.")
 
         # Warnings
         if np.any(np.array(ap) > 1.0):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -352,7 +352,11 @@ def sorted_krylov_schur(P, m, z='LM'):
     # WE NEED REAL VECTORS! G-PCCA and PCCA only work with real vectors!!
     # We take the sequence of 1-D arrays and stack them as columns to make a single 2-D array.
     Subspace = np.column_stack([x.array for x in E.getInvariantSubspace()])
-    
+
+    R = E.getDS().getMat(SLEPc.DS.MatType.A)
+    R.view()
+    R = R.getDenseArray().astype(np.float32)
+
     # Raise, if X contains complex values!
     if not np.all(np.isreal(Subspace)):
         raise TypeError("The orthonormal basis of the subspace returned by Krylov-Schur is not real.",
@@ -419,7 +423,7 @@ def sorted_krylov_schur(P, m, z='LM'):
                       "column space of P*Q and/or Q*L is not equal to m (L is a diagonal "
                       "matrix with the sorted top eigenvalues on the diagonal).")
     
-    return Q, top_eigenvals, top_eigenvals_error
+    return R, Q, top_eigenvals, top_eigenvals_error
 
 
 def sorted_schur(P, m, z='LM', method='brandts'):
@@ -493,11 +497,8 @@ def sorted_schur(P, m, z='LM', method='brandts'):
     elif method == 'scipy':
         R, Q = sorted_scipy_schur(P, m, z=z)
     elif method == 'krylov':
-        Q, _, _ = sorted_krylov_schur(P, m, z=z)
+        R, Q, _, _ = sorted_krylov_schur(P, m, z=z)
     else:
         raise ValueError(f"Unknown method `{method!r}`.")
        
-    if method == 'krylov':
-        return Q
-
     return R, Q

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -381,14 +381,12 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         T, _ = rsf2csf(R, Q)
         eigenvalues = np.diag(T)[:k]
 
+        # check for splitting pairs of complex conjugates
         if (m < n):
             eigenval_in = eigenvalues[m - 1]
             eigenval_out = eigenvalues[m]
-            # Don't separate conjugate eigenvalues (corresponding to 2x2-block in R).
             if np.isclose(eigenval_in, np.conj(eigenval_out)):
-                block_split = True
-                warnings.warn("Clustering into " + str(m) + " clusters will split conjugate eigenvalues! "
-                                                            "Request one cluster more or less.")
+                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvales. Request one cluster more or less. ')
 
         # Warnings
         if np.any(np.array(ap) > 1.0):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -265,6 +265,8 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
         # Computes the error (based on the residual norm) associated with the i-th computed eigenpair.
         eigenval_error = E.computeError(i)
         top_eigenvals_error.append(eigenval_error)
+
+    # cut off excess dimensions also for the eigenvalues
     top_eigenvals = np.asarray(top_eigenvals)[:m]
     top_eigenvals_error = np.asarray(top_eigenvals_error)[:m]
 

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -388,7 +388,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
             if np.isclose(eigenval_in, np.conj(eigenval_out)):
                 raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                                  f'Request one cluster more or less. ')
-            Q, R, eigenvalues = Q[:m], R[:m, :m], eigenvalues[:m]
+            Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m]
 
         # Warnings
         if np.any(np.array(ap) > 1.0):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -265,14 +265,14 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
         # Computes the error (based on the residual norm) associated with the i-th computed eigenpair.
         eigenval_error = E.computeError(i)
         top_eigenvals_error.append(eigenval_error)
-    top_eigenvals = np.asarray(top_eigenvals)
-    top_eigenvals_error = np.asarray(top_eigenvals_error)
+    top_eigenvals = np.asarray(top_eigenvals)[:m]
+    top_eigenvals_error = np.asarray(top_eigenvals_error)[:m]
 
     dummy = np.dot(P, csr_matrix(Q) if issparse(P) else Q)
     if issparse(dummy):
         dummy = dummy.toarray()
 
-    dummy1 = np.dot(Q, np.diag(top_eigenvals[:m]))
+    dummy1 = np.dot(Q, np.diag(top_eigenvals))
 #     dummy2 = np.concatenate((dummy, dummy1), axis=1)
     dummy3 = subspace_angles(dummy, dummy1)
 #     test1 = ( ( matrix_rank(dummy2) - matrix_rank(dummy) ) == 0 )

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -386,8 +386,9 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
             eigenval_in = eigenvalues[m - 1]
             eigenval_out = eigenvalues[m]
             if np.isclose(eigenval_in, np.conj(eigenval_out)):
-                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvales. '
+                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                                  f'Request one cluster more or less. ')
+            Q, R, eigenvalues = Q[:m], R[:m, :m], eigenvalues[:m]
 
         # Warnings
         if np.any(np.array(ap) > 1.0):


### PR DESCRIPTION
This removes the need to have SLEPSc installed when running GPCCA using `brandts` to sort the real schur decomposition. It does so by not running `top_eigenvalues` prior to computing the schur decomposition. Instead, the real sorted schur decomposition is transformed to a complex schur decomposition using `scipy.linalg.rsf2csf`. The diagonal of the complex schur form is then used to read of the eigenvalues, which in turn are used to check whether we are splitting a block of complex conjugates. See below for tests and preformance. 