### PR TITLE
Restructure `sorted_schur` 

### DIFF
--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1113,11 +1113,11 @@ class GPCCA(object):
             else:
                 # if we are using pre-computed decomposition, check splitting
                 if m < n:
-                    if len(self.eigenvalues) < m+1:
+                    if len(self.eigenvalues) < m:
                         raise ValueError(f"Can't check compl. conj. block splitting for {m} clusters with only "
                                          f"{len(self.eigenvalues)} eigenvalues")
                     else:
-                        if _check_conj_splitting(self.eigenvalues, m):
+                        if _check_conj_splitting(self.eigenvalues[:m]):
                             raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                                              f'Request one cluster more or less. ')
                         print('INFO: Using pre-computed schur decomposition')

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -827,6 +827,9 @@ def gpcca_coarsegrain(P, m, eta=None, z='LM', method='brandts'):
 
     chi = GPCCA(P, eta, z, method).optimize(m).memberships
     W = np.linalg.pinv(np.dot(chi.T, np.diag(eta)).dot(chi))
+    #todo just change the computation of A to work correctly with sparse matrices
+    if issparse(P):
+        P = P.toarray()
     A = np.dot(chi.T, np.diag(eta)).dot(P).dot(chi)
     P_coarse = W.dot(A)
                        

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -58,34 +58,6 @@ from msmtools.util.sorted_schur import _check_conj_split
 # Machine double floating precision:
 eps = np.finfo(np.float64).eps
 
-
-def _find_twoblocks(R):
-    r"""
-    This function checks the sorted part of the Schurform `R` for 2x2-blocks. 
-    If a 2x2-block (corresponding to two complex conjugate eigenvalues, that MUST NOT be splitted) 
-    at positions (``rr_i;i``, ``rr_i;i+1``, ``rr_i+1;i``, ``rr_i+1;i+1``) is found, the row-index ``i`
-    of the first row of the 2x2-block is identified as invalid row-index and ``n_cluster = i+1``
-    is excluded from the array of valid cluster numbers that is returned by this function.
-    
-    Parameters
-    ----------
-    R : ndarray (n,n)
-        (Partially) sorted real Schur matrix of
-        :math:`\tilde{P} = \mathtt{diag}(\sqrt{\eta}) P \mathtt{diag}(1.0. / \sqrt{eta})`
-        such that :math:`\tilde{P} Q = Q R` with the (partially) sorted matrix 
-        of Schur vectors :math:`Q` holds.
-        
-    Returns
-    -------
-    validclusters : ndarray (l,)
-        Array of valid cluster numbers.
-    """
-    
-    badindices = np.asarray(np.abs(np.diag(R, -1)) > 1000 * eps).nonzero()[0]
-    validclusters = np.setdiff1d(np.arange(R.shape[0] + 1), badindices + 1)
-    
-    return validclusters
-
   
 def _gram_schmidt_mod(X, eta):
     r"""

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -1075,10 +1075,10 @@ class GPCCA(object):
         if method not in ['brandts', 'krylov']:
             raise ValueError("You didn't give a valid method to determine the invariant subspace.")
           
-        if issparse(P) and method != 'krylov':
-            warnings.warn("Sorted Schur decoposition via the method `brandts` is only implemented "
-                          "for dense matrices. Converting sparse transition matrix to dense ndarray.")
-            P = P.toarray()
+        # if issparse(P) and method != 'krylov':
+        #     warnings.warn("Sorted Schur decoposition via the method `brandts` is only implemented "
+        #                   "for dense matrices. Converting sparse transition matrix to dense ndarray.")
+        #     P = P.toarray()
 
         self.P = P
         if eta is None:
@@ -1109,7 +1109,7 @@ class GPCCA(object):
                 raise ValueError(f"The first dimension of X is `{Xdim1}`. This doesn't match "
                                  f"with the dimension of R [{Rdim1}, {Rdim2}].")
             if Rdim2 < m:
-                self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
+                self.X, self.R, self.eigenvalues = _do_schur(self.P.copy(), self.eta, m, self.z, self.method)
             else:
                 # if we are using pre-computed decomposition, check splitting
                 if m < n:
@@ -1122,7 +1122,7 @@ class GPCCA(object):
                                              f'Request one cluster more or less. ')
                         print('INFO: Using pre-computed schur decomposition')
         else:
-            self.X, self.R, self.eigenvalues = _do_schur(self.P, self.eta, m, self.z, self.method)
+            self.X, self.R, self.eigenvalues = _do_schur(self.P.copy(), self.eta, m, self.z, self.method)
 
     def minChi(self, m_min, m_max):
         r"""
@@ -1319,9 +1319,8 @@ class GPCCA(object):
         n_closed_components = len(closed_components)
         
         # Calculate Schur matrix R and Schur vector matrix X, if not adequately given.
-
         self._do_schur_helper(max(m_list))
-
+        
         # Initialize lists to collect results.
         chi_list = []
         rot_matrix_list = []

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -748,7 +748,7 @@ def coarsegrain(P, eta, chi):
     return P_coarse
 
 
-def gpcca_coarsegrain(P, eta, m, z='LM', method='brandts'):
+def gpcca_coarsegrain(P, m, eta=None, z='LM', method='brandts'):
     r"""
     Coarse-grains the transition matrix `P` to `m` sets using G-PCCA.
     Performs optimized spectral clustering via G-PCCA and coarse-grains
@@ -822,6 +822,9 @@ def gpcca_coarsegrain(P, eta, m, z='LM', method='brandts'):
     
     """                  
     #Matlab: Pc = pinv(chi'*diag(eta)*chi)*(chi'*diag(eta)*P*chi)
+    if eta is None:
+        eta = np.true_divide(np.ones(P.shape[0]), P.shape[0])
+
     chi = GPCCA(P, eta, z, method).optimize(m).memberships
     W = np.linalg.pinv(np.dot(chi.T, np.diag(eta)).dot(chi))
     A = np.dot(chi.T, np.diag(eta)).dot(P).dot(chi)

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -222,17 +222,6 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
 
     # Make a Schur decomposition of P_bar and sort the Schur vectors (and form).
     R, Q, eigenvalues = sorted_schur(P_bar, m, z, method, tol_krylov=tol_krylov) #Pbar!!!
-
-    # if m - 1 not in _find_twoblocks(R): #TODO: Rethink this, mb only for stuff sorted with brandts...
-    #     warnings.warn("Coarse-graining with " + str(m) + " states cuts through "
-    #                   + "a block of complex conjugate eigenvalues in the Schur "
-    #                   + "form. The result will be of questionable meaning. "
-    #                   + "Please increase/decrease number of states by one.")
-    # # Since the Schur form R and Schur vectors are only partially
-    # # sorted, one doesn't need the whole R and Schur vector matrix Q.
-    # # Take only the sorted Schur form and the vectors belonging to it.
-    # R = R[:m, :m]
-    # Q = Q[:, :m]
     
     # Orthonormalize the sorted Schur vectors Q via modified Gram-Schmidt-orthonormalization,
     # if the (Schur)vectors aren't orthogonal!

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -23,14 +23,14 @@ def _initialize_matrix(M, P):
         M.createDense(list(np.shape(P)), array=P)
 
 
-def _check_conj_split(m, eigenvalues):
+def _check_conj_split(eigenvalues):
     """Check whether using m eigenvalues cuts through a block of complex conjugates.
 
     If the last (m'th) e-val is not real, check whether it forms a compl. conj. pair with the second last e-val. If
     that's not the case, then choosing m clusters would cut through a block of complex conjugates.
     """
 
-    last_eigenvalue, second_last_eigenvalue = eigenvalues[m], eigenvalues[m-1]
+    last_eigenvalue, second_last_eigenvalue = eigenvalues[-1], eigenvalues[-2]
     splits_block = False
     if last_eigenvalue.imag > eps:
         splits_block = not np.isclose(last_eigenvalue, np.conj(second_last_eigenvalue))
@@ -299,7 +299,7 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
 
     # check for splitting pairs of complex conjugates
     if (m < n):
-        if _check_conj_split(m, eigenvalues):
+        if _check_conj_split(eigenvalues[:m]):
             raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                              f'Request one cluster more or less. ')
         Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m+1]

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -297,6 +297,6 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m+1]
 
     # check the returned schur decomposition
-    _check_schur(P=P, Q=Q, R=R, eigenvalues=eigenvalues, method=method)
+    _check_schur(P=P, Q=Q, R=R, eigenvalues=eigenvalues[:m], method=method)
        
     return R, Q, eigenvalues

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -300,9 +300,8 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
     # check for splitting pairs of complex conjugates
     if (m < n):
         if _check_conj_split(eigenvalues[:m]):
-            warnings.warn(f"Clustering into {m} clusters will split conjugate eigenvalues. "
-                          f"Increasing `m` to {m+1} ")
-            m += 1
+            raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
+                             f'Request one cluster more or less. ')
         Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m]
 
     # check the returned schur decomposition

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -24,12 +24,18 @@ def _initialize_matrix(M, P):
 
 
 def _check_conj_split(m, eigenvalues):
-    """Utility function to check whether using m eigenvalues cuts through a block of complex conjugates
-    """
-    eigenval_in = eigenvalues[m - 1]
-    eigenval_out = eigenvalues[m]
+    """Check whether using m eigenvalues cuts through a block of complex conjugates.
 
-    return np.isclose(eigenval_in, np.conj(eigenval_out))
+    If the last (m'th) e-val is not real, check whether it forms a compl. conj. pair with the second last e-val. If
+    that's not the case, then choosing m clusters would cut through a block of complex conjugates.
+    """
+
+    last_eigenvalue, second_last_eigenvalue = eigenvalues[m], eigenvalues[m-1]
+    splits_block = False
+    if last_eigenvalue.imag > eps:
+        splits_block = not np.isclose(last_eigenvalue, np.conj(second_last_eigenvalue))
+
+    return splits_block
 
 
 def _check_schur(P, Q, R, eigenvalues, method = ""):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -214,7 +214,7 @@ def sorted_brandts_schur(P, k, z='LM'):
     if np.any(np.array(ap) > 1.0):
         warnings.warn("Reordering of Schur matrix was inaccurate.")
 
-    # comptue eigenvalues
+    # compute eigenvalues
     T, _ = rsf2csf(R, Q)
     eigenvalues = np.diag(T)[:k]
 

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -300,8 +300,9 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
     # check for splitting pairs of complex conjugates
     if (m < n):
         if _check_conj_split(eigenvalues[:m]):
-            raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
-                             f'Request one cluster more or less. ')
+            warnings.warn(f"Clustering into {m} clusters will split conjugate eigenvalues. "
+                          f"Increasing `m` to {m+1} ")
+            m += 1
         Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m]
 
     # check the returned schur decomposition

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -32,7 +32,48 @@ def _check_conj_split(m, eigenvalues):
     return np.isclose(eigenval_in, np.conj(eigenval_out))
 
 
-def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
+def _check_schur(P, Q, R, eigenvalues, method = ""):
+    """Utility function to run a number of checks on the sorted schur decomposition
+    """
+
+    # check the dimensions
+    if Q.shape[1] != len(eigenvalues):
+        raise ValueError(f"Number of schur vectors does not match number of eigenvalues for method `{method}`")
+    if R.shape[0] != R.shape[1]:
+        raise ValueError(f"R is not rectangular for method `{method}`")
+    if P.shape[0] != Q.shape[0]:
+        raise ValueError(f"First dimension in P does not match first dimension in Q for method `{method}`")
+    if R.shape[0] != Q.shape[1]:
+        raise ValueError(f"First dimension in R does not match second dimension in Q for method `{method}`")
+
+    dummy = np.dot(P, csr_matrix(Q) if issparse(P) else Q)
+    if issparse(dummy):
+        dummy = dummy.toarray()
+
+    dummy1 = np.dot(Q, np.diag(eigenvalues))
+    #     dummy2 = np.concatenate((dummy, dummy1), axis=1)
+    dummy3 = subspace_angles(dummy, dummy1)
+    #     test1 = ( ( matrix_rank(dummy2) - matrix_rank(dummy) ) == 0 )
+    test2 = np.allclose(dummy3, 0.0, atol=1e-8, rtol=1e-5)
+    test3 = (dummy3.shape[0] == m)
+    dummy4 = subspace_angles(dummy, Q)
+    test4 = np.allclose(dummy4, 0.0, atol=1e-6, rtol=1e-5)
+    if not test4:
+        raise ValueError(f"According to scipy.linalg.subspace_angles() `{method}` "
+                         f"return an invariant subspace of P. The subspace angles are: `{dummy4}`.")
+    elif not test2:
+        warnings.warn(f"According to scipy.linalg.subspace_angles() `{method}` didn't "
+                      f"return the invariant subspace associated with the top m eigenvalues, "
+                      f"since the subspace angles between the column spaces of P*Q and Q*L "
+                      f"aren't near zero (L is a diagonal matrix with the "
+                      f"sorted top eigenvalues on the diagonal). The subspace angles are: `{dummy3}`.")
+    elif not test3:
+        warnings.warn(f"According to scipy.linalg.subspace_angles() the dimension of the "
+                      f"column space of P*Q and/or Q*L is not equal to m (L is a diagonal "
+                      f"matrix with the sorted top eigenvalues on the diagonal), method = `{method}`")
+
+
+def sorted_krylov_schur(P, k, z='LM', tol=1e-16):
     r"""
     Calculate an orthonormal basis of the subspace associated with the `m`
     dominant eigenvalues of `P` using the Krylov-Schur method as implemented
@@ -79,22 +120,6 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
     """
     from petsc4py import PETSc
     from slepc4py import SLEPc
-
-    n = P.shape[0]
-    if m < n:
-        k = m + 1
-    elif m == n:
-        k = m
-
-    # Calculate the top m+1 eigenvalues and secure that you
-    # don't separate conjugate eigenvalues (corresponding to 2x2-block in R),
-    # if you take the dominant m eigenvalues to cluster the data.
-    # top_eigenvals, block_split = top_eigenvalues(P, m, z=z, tol=tol)
-    
-    # if block_split:
-    #     raise ValueError(f"Clustering P into `{m}` clusters will split "
-    #                      f"a pair of conjugate eigenvalues. Choose one cluster "
-    #                      f"more or less.")
     
     M = PETSc.Mat().create()
     _initialize_matrix(M, P)
@@ -140,88 +165,58 @@ def sorted_krylov_schur(P, m, z='LM', tol=1e-16):
     # We take the sequence of 1-D arrays and stack them as columns to make a single 2-D array.
     Subspace = np.column_stack([x.array for x in E.getInvariantSubspace()])
 
-    R = E.getDS().getMat(SLEPc.DS.MatType.A)
-    R.view()
-    R = R.getDenseArray().astype(np.float32)
-
     # Raise, if X contains complex values!
     if not np.all(np.isreal(Subspace)):
         raise TypeError("The orthonormal basis of the subspace returned by Krylov-Schur is not real.",
                         "G-PCCA needs real basis vectors to work.")
-    
-    # The above seems to do the same as scipy.schur with sorting, 
-    # but if too many converge the returned space is too big.
-    # Cuting the rest off seems to work, but we don't know for sure...
-#     if np.shape(Subspace)[1] > m:
-#         warnings.warn("The size of the orthonormal basis of the subspace returned by Krylov-Schur " 
-#                       + "is to large. The excess is cut off. This should be ok as long as no error "
-#                       + "is raised later, when testing, if the remaining subspace Q[:,:k] is an "
-#                       + "invariant subspace associated with the sorted top k eigenvalues.")
-    
+
+    # Get the schur form
+    R = E.getDS().getMat(SLEPc.DS.MatType.A)
+    R.view()
+    R = R.getDenseArray().astype(np.float32)
+
     # Gets the number of converged eigenpairs. 
     nconv = E.getConverged()
     # Warn, if nconv smaller than k.
     if nconv < k:
-        warnings.warn(f"The number of converged eigenpairs is `{nconv}`, but `{k}` clusters were requested.")
+        warnings.warn(f"The number of converged eigenpairs is `{nconv}`, but `{k}` were requested.")
     # Collect the k dominant eigenvalues.
-    top_eigenvals = []
-    top_eigenvals_error = []
+    eigenvalues = []
+    eigenvalues_error = []
     for i in range(nconv):
         # Get the i-th eigenvalue as computed by solve().
         eigenval = E.getEigenvalue(i)
-        top_eigenvals.append(eigenval)
+        eigenvalues.append(eigenval)
         # Computes the error (based on the residual norm) associated with the i-th computed eigenpair.
         eigenval_error = E.computeError(i)
-        top_eigenvals_error.append(eigenval_error)
+        eigenvalues_error.append(eigenval_error)
 
     # convert lists with eigenvalues and errors to arrays (while keeping excess eigenvalues and errors)
-    top_eigenvals = np.asarray(top_eigenvals)
-    top_eigenvals_error = np.asarray(top_eigenvals_error)
-
-    # check whether using m clusters would split a pair of complex conjugates
-    if (m < n):
-        if _check_conj_split(m, top_eigenvals):
-            raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
-                             f'Request one cluster more or less. ')
-
-    # Cut off the one extra dimension we introduced, and any extra dim. that may stem from too many eigenvalues conv.
-    Q = Subspace[:, :m]
-    R = R[:m, :m]
-    top_eigenvals, top_eigenvals_error = top_eigenvals[:m+1], top_eigenvals_error[:m+1]
-
-    dummy = np.dot(P, csr_matrix(Q) if issparse(P) else Q)
-    if issparse(dummy):
-        dummy = dummy.toarray()
-
-    dummy1 = np.dot(Q, np.diag(top_eigenvals[:m]))
-#     dummy2 = np.concatenate((dummy, dummy1), axis=1)
-    dummy3 = subspace_angles(dummy, dummy1)
-#     test1 = ( ( matrix_rank(dummy2) - matrix_rank(dummy) ) == 0 )
-    test2 = np.allclose(dummy3, 0.0, atol=1e-8, rtol=1e-5)
-    test3 = (dummy3.shape[0] == m)
-    dummy4 = subspace_angles(dummy, Q)
-    test4 = np.allclose(dummy4, 0.0, atol=1e-6, rtol=1e-5)
-    if not test4:
-        raise ValueError(f"According to scipy.linalg.subspace_angles() Krylov-Schur didn't "
-                         f"return an invariant subspace of P. The subspace angles are: `{dummy4}`.")
-#     elif not test1:
-#         warnings.warn("According to numpy.linalg.matrix_rank() Krylov-Schur didn't "
-#                       + "return the invariant subspace associated with the top m "
-#                       + " eigenvalues, since (P*Q|Q*L) (horizontally stacked) and P*Q don't "
-#                       + "have the same rank (L is a diagonal matrix with the "
-#                       + "sorted top eigenvalues on the diagonal).")
-    elif not test2:
-        warnings.warn(f"According to scipy.linalg.subspace_angles() Krylov-Schur didn't "
-                      f"return the invariant subspace associated with the top m eigenvalues, "
-                      f"since the subspace angles between the column spaces of P*Q and Q*L "
-                      f"aren't near zero (L is a diagonal matrix with the "
-                      f"sorted top eigenvalues on the diagonal). The subspace angles are: `{dummy3}`.")
-    elif not test3:
-        warnings.warn("According to scipy.linalg.subspace_angles() the dimension of the "
-                      "column space of P*Q and/or Q*L is not equal to m (L is a diagonal "
-                      "matrix with the sorted top eigenvalues on the diagonal).")
+    eigenvalues = np.asarray(eigenvalues)
+    eigenvalues_error = np.asarray(eigenvalues_error)
     
-    return R, Q, top_eigenvals, top_eigenvals_error
+    return R, Q, eigenvalues, eigenvalues_error
+
+
+def sorted_brandts_schur(P, k, z='LM'):
+    """Utility function to compute a sorted schur decomp. using scipy for the decomp. and `brandts` for sorting
+    """
+
+    # Make a Schur decomposition of P.
+    R, Q = schur(P, output='real')
+
+    # Sort the Schur matrix and vectors.
+    Q, R, ap = sort_real_schur(Q, R, z=z, b=k)
+
+    # Warnings
+    if np.any(np.array(ap) > 1.0):
+        warnings.warn("Reordering of Schur matrix was inaccurate.")
+
+    # comptue eigenvalues
+    T, _ = rsf2csf(R, Q)
+    eigenvalues = np.diag(T)[:k]
+
+    return R, Q, eigenvalues
 
 
 def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
@@ -279,42 +274,30 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         warnings.warn("Sparse implementation is only avaiable for `method='krylov'`, densifying.")
         P = P.toarray()
 
+    # make sure we have enough eigenvalues to check for block splitting
+    n = P.shape[0]
+    if m < n:
+        k = m + 1
+    elif m == n:
+        k = m
+
+    # compute the sorted schur decomposition
     if method == 'brandts':
-        # Calculate the top m+1 eigenvalues and secure that you
-        # don't separate conjugate eigenvalues (corresponding to 2x2-block in R),
-        # if you take the dominant m eigenvalues to cluster the data.
-        #  _ = top_eigenvalues(P, m, z=z, tol=tol_krylov)
-   
-        # Make a Schur decomposition of P.
-        R, Q = schur(P, output='real')
-
-        # sort one more than requested
-        n = P.shape[0]
-        if m < n:
-            k = m + 1
-        elif m == n:
-            k = m
-        
-        # Sort the Schur matrix and vectors.
-        Q, R, ap = sort_real_schur(Q, R, z=z, b=k)
-
-        # comptue eigenvalues
-        T, _ = rsf2csf(R, Q)
-        eigenvalues = np.diag(T)[:k]
-
-        # check for splitting pairs of complex conjugates
-        if (m < n):
-            if _check_conj_split(m, eigenvalues):
-                raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
-                                 f'Request one cluster more or less. ')
-            Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m+1]
-
-        # Warnings
-        if np.any(np.array(ap) > 1.0):
-            warnings.warn("Reordering of Schur matrix was inaccurate.")
+        R, Q, eigenvalues = sorted_brandts_schur(P, k, z=z)
     elif method == 'krylov':
-        R, Q, eigenvalues, _ = sorted_krylov_schur(P, m, z=z, tol=tol_krylov)
+        R, Q, eigenvalues, _ = sorted_krylov_schur(P, k, z=z, tol=tol_krylov)
     else:
         raise ValueError(f"Unknown method `{method!r}`.")
+
+    # check for splitting pairs of complex conjugates
+    if (m < n):
+        if _check_conj_split(m, eigenvalues):
+            raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
+                             f'Request one cluster more or less. ')
+        Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m + 1]
+
+    # check the returned schur decomposition
+
+
        
     return R, Q, eigenvalues

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -302,9 +302,9 @@ def sorted_schur(P, m, z='LM', method='brandts', tol_krylov=1e-16):
         if _check_conj_split(eigenvalues[:m]):
             raise ValueError(f'Clustering into {m} clusters will split conjugate eigenvalues. '
                              f'Request one cluster more or less. ')
-        Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m+1]
+        Q, R, eigenvalues = Q[:, :m], R[:m, :m], eigenvalues[:m]
 
     # check the returned schur decomposition
-    _check_schur(P=P, Q=Q, R=R, eigenvalues=eigenvalues[:m], method=method)
+    _check_schur(P=P, Q=Q, R=R, eigenvalues=eigenvalues, method=method)
        
     return R, Q, eigenvalues

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -70,7 +70,7 @@ def _check_schur(P, Q, R, eigenvalues, method = ""):
                          f"return an invariant subspace of P. The subspace angles are: `{dummy4}`.")
     elif not test2:
         warnings.warn(f"According to scipy.linalg.subspace_angles() `{method}` didn't "
-                      f"return the invariant subspace associated with the top m eigenvalues, "
+                      f"return the invariant subspace associated with the top k eigenvalues, "
                       f"since the subspace angles between the column spaces of P*Q and Q*L "
                       f"aren't near zero (L is a diagonal matrix with the "
                       f"sorted top eigenvalues on the diagonal). The subspace angles are: `{dummy3}`.")
@@ -82,7 +82,7 @@ def _check_schur(P, Q, R, eigenvalues, method = ""):
 
 def sorted_krylov_schur(P, k, z='LM', tol=1e-16):
     r"""
-    Calculate an orthonormal basis of the subspace associated with the `m`
+    Calculate an orthonormal basis of the subspace associated with the `k`
     dominant eigenvalues of `P` using the Krylov-Schur method as implemented
     in SLEPc.
     ------------------------------------------------------------------------
@@ -110,7 +110,7 @@ def sorted_krylov_schur(P, k, z='LM', tol=1e-16):
     P : ndarray (n,n)
         Transition matrix (row-stochastic).
         
-    m : int
+    k : int
         Number of clusters to group into.
         
     z : string, (default='LM')

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -35,6 +35,8 @@ def _check_conj_split(m, eigenvalues):
 def _check_schur(P, Q, R, eigenvalues, method = ""):
     """Utility function to run a number of checks on the sorted schur decomposition
     """
+    
+    m = len(eigenvalues)
 
     # check the dimensions
     if Q.shape[1] != len(eigenvalues):

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -35,7 +35,7 @@ def _check_conj_split(m, eigenvalues):
 def _check_schur(P, Q, R, eigenvalues, method = ""):
     """Utility function to run a number of checks on the sorted schur decomposition
     """
-    
+
     m = len(eigenvalues)
 
     # check the dimensions
@@ -170,7 +170,7 @@ def sorted_krylov_schur(P, k, z='LM', tol=1e-16):
     # OPEN QUESTION: Are we sure that the returned basis vector are always real??
     # WE NEED REAL VECTORS! G-PCCA and PCCA only work with real vectors!!
     # We take the sequence of 1-D arrays and stack them as columns to make a single 2-D array.
-    Subspace = np.column_stack([x.array for x in E.getInvariantSubspace()])
+    Q = np.column_stack([x.array for x in E.getInvariantSubspace()])
 
     # Get the schur form
     R = E.getDS().getMat(SLEPc.DS.MatType.A)

--- a/msmtools/util/sorted_schur.py
+++ b/msmtools/util/sorted_schur.py
@@ -66,7 +66,7 @@ def _check_schur(P, Q, R, eigenvalues, method = ""):
     dummy4 = subspace_angles(dummy, Q)
     test4 = np.allclose(dummy4, 0.0, atol=1e-6, rtol=1e-5)
     if not test4:
-        raise ValueError(f"According to scipy.linalg.subspace_angles() `{method}` "
+        raise ValueError(f"According to scipy.linalg.subspace_angles() `{method}`  didn't "
                          f"return an invariant subspace of P. The subspace angles are: `{dummy4}`.")
     elif not test2:
         warnings.warn(f"According to scipy.linalg.subspace_angles() `{method}` didn't "


### PR DESCRIPTION
I found a bug with using a pre-computed schur decomposition, with didn't have enough eigenvalues to check for block-splitting when the original decomp. was computed using `krylov`. I fixed that bug and decided to re-structure the `sorted_schur` functions a bit, so that `brandts` and `krylov` are more consistent in that...
- there are functions `sorted_krylov_schur` and `sorted_brandts_schur` which each return Q, R and the eigenvalues
- in both cases, we first compute the decomposition and then check for splitting blocks of complex conjugates, using the same utility function
- we execute the same checks on the computed schur decomposition, no matter whether we computed it using `brandts` or `krylov`

One thing I wanted your opinion on: in case we choose a number `m` that would split a block of complex conjugates, so far, we just raise an exception and the user has to start again. It may be more convenient to simply raise a warning and to use the schur decomposition of size `m+1`, which we have computed already. In case the user prefers using `m-1`, that's no problem either since we saved the decomposition, so it's only a matter of subsetting it. What do you think?