### PR TITLE
Memory issue

### DIFF
--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -230,7 +230,7 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
         Q = _gram_schmidt_mod(Q, eta)
         # Transform the orthonormalized Schur vectors of P_bar back 
         # to orthonormalized Schur vectors X of P.
-        X = Q / np.sqrt(eta)[:, None]
+        X = np.true_divide(Q, np.sqrt(eta)[:, None])
     else:
         # Search for the constant (Schur) vector, if explicitly present.
         n, m = Q.shape

--- a/msmtools/analysis/dense/gpcca.py
+++ b/msmtools/analysis/dense/gpcca.py
@@ -245,7 +245,7 @@ def _do_schur(P, eta, m, z='LM', method='brandts', tol_krylov=1e-16):
         Q[:, max_i] = Q[:, 0]
         # Transform the orthonormalized Schur vectors of P_bar back 
         # to orthonormalized Schur vectors X of P.
-        X = Q / np.sqrt(eta)[:, None]
+        X = np.true_divide(Q, np.sqrt(eta)[:, None])
         # Set first (Schur) vector equal 1.
         X[:, 0] = 1.0
          


### PR DESCRIPTION
This adresses a memory issue we had with very large sample sizes. Essentially, we should never create a matrix of size `n_samples x n_samples`. Previously, we did this in commands such as `np.diag(1. / np.sqrt(eta)`, which raises the memory error. 